### PR TITLE
feat: add script to pull MosaiCatcher containers with hash-based naming

### DIFF
--- a/.github/scripts/pull-apptainer-containers.sh
+++ b/.github/scripts/pull-apptainer-containers.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# Submit SLURM jobs to pull MosaiCatcher pipeline containers in parallel
+# Each container gets its own sbatch job
+#
+# Usage: ./pull-apptainer-containers.sh [cache_dir] [temp_dir]
+#
+# Example:
+#   ./pull-apptainer-containers.sh /scratch_cached/korbel/shared/apptainer_cache /tmp
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
+
+CACHE_DIR="${1:-/scratch_cached/korbel/shared/apptainer_cache}"
+TEMP_DIR="${2:-/tmp}"
+
+# Read version from VERSION file
+VERSION=$(cat "$REPO_ROOT/VERSION")
+ASSEMBLIES=(hg38 T2T mm10 mm39)
+
+echo "Using VERSION: $VERSION"
+echo "Cache directory: $CACHE_DIR"
+echo "Temp directory: $TEMP_DIR"
+echo ""
+
+mkdir -p "$CACHE_DIR"
+
+# Submit sbatch job for each container
+for assembly in "${ASSEMBLIES[@]}"; do
+    uri="docker://ghcr.io/friendsofstrandseq/mosaicatcher-pipeline:${assembly}-v${VERSION}"
+    hash=$(echo -n "$uri" | md5sum | cut -d' ' -f1)
+    output_file="$CACHE_DIR/${hash}.simg"
+
+    # Skip if already exists
+    if [[ -f "$output_file" ]]; then
+        echo "✓ $assembly ($hash) already cached"
+        continue
+    fi
+
+    echo "Submitting sbatch job for $assembly..."
+
+    sbatch \
+        --mem=16G \
+        --time=2:00:00 \
+        --job-name="apptainer-pull-mosaicatcher-${VERSION}-${assembly}" \
+        --output="$CACHE_DIR/apptainer-pull-mosaicatcher-${VERSION}-${assembly}-%j.log" \
+        --wrap="
+            set -euo pipefail
+            export TMPDIR='$TEMP_DIR'
+            export APPTAINER_CACHEDIR='$CACHE_DIR/cache'
+            export APPTAINER_TMPDIR='$TEMP_DIR'
+            echo '['\$(date +'%Y-%m-%d %H:%M:%S')'] Pulling $assembly: $uri'
+            apptainer pull '$output_file' '$uri'
+            echo '['\$(date +'%Y-%m-%d %H:%M:%S')'] ✓ Completed: $assembly'
+            ls -lh '$output_file'
+        "
+done
+
+echo ""
+echo "All sbatch jobs submitted. Check job status with: squeue -u $USER"

--- a/workflow/scripts/toolbox/setup_shared_caches.sh
+++ b/workflow/scripts/toolbox/setup_shared_caches.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# setup_shared_caches.sh
+#
+# Creates shared MosaiCatcher cache directories on the EMBL HPC with correct
+# group permissions. Run once by the group admin before first use.
+#
+# Usage: bash workflow/scripts/toolbox/setup_shared_caches.sh
+
+set -euo pipefail
+
+GROUP="korbel"
+
+DIRS=(
+    "/scratch/korbel/shared/apptainer_cache"   # Apptainer blobs + .simg files
+    "/scratch_cached/korbel/references"         # Reference genomes + BWA indexes
+    "/g/korbel2/shared/conda_envs"              # Conda environments
+)
+
+echo "Creating shared cache directories for group: $GROUP"
+
+for DIR in "${DIRS[@]}"; do
+    mkdir -p "$DIR"
+    chgrp "$GROUP" "$DIR"
+    chmod 2775 "$DIR"                  # setgid + rwxrwxr-x
+    setfacl -d -m g::rwx "$DIR"       # default ACL: new files inherit group-write
+    setfacl -d -m o::rx  "$DIR"
+    echo "  OK  $DIR"
+done
+
+echo ""
+echo "Done. Verify with: ls -la /scratch/korbel/shared/ /scratch_cached/korbel/ /g/korbel2/shared/"


### PR DESCRIPTION
## Summary
- Add SLURM batch job submission script for pulling container images
- Dynamically computes container hashes from VERSION file
- Submits separate sbatch job for each assembly (hg38, T2T, mm10, mm39)
- Resolves Snakemake DAG construction container caching issue

## Details
The script fixes a chicken-and-egg problem where Snakemake needs container images during DAG construction (to compute conda env hashes) but only pulls them during job execution. By pre-pulling containers with the correct hash-based filenames expected by Snakemake, the workflow can proceed without cache misses.

Each container:
- Gets its own sbatch job for parallel pulling
- Is named as `{hash}.simg` where hash = MD5(container_uri)
- Includes version and pipeline name in job metadata
- Skips if already cached

## Test plan
- [ ] Run script with default cache directory
- [ ] Verify container files are created with correct hash-based names
- [ ] Confirm Snakemake recognizes cached containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)